### PR TITLE
Menghapus Property private int dayJoined; pada Employee.java

### DIFF
--- a/src/lib/Employee.java
+++ b/src/lib/Employee.java
@@ -11,7 +11,6 @@ public class Employee {
 	
 	private int yearJoined;
 	private int monthJoined;
-	private int dayJoined;
 	private int monthWorkingInYear;
 	
 	private boolean isForeigner;


### PR DESCRIPTION
Property tersebut dihapus karena tidak digunakan namun dideklarasikan di dalam public class Employee. Untuk variable address, digunakan di dalam public Employee yang dideklarasikan dengan referensi this.dayJoined = dayJoined; dalam bentuk tipe variable Integer.